### PR TITLE
更新依赖版本，调整部分语法以兼容新版laravel (#3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
   - hhvm
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
-        "illuminate/support": "~5.1",
-        "guzzlehttp/promises": "^1.0"
+        "php": "^7.1",
+        "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
+        "guzzlehttp/promises": "^1.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0|~5.0"
+        "phpunit/phpunit": "^7.0|^8.0|^9.0"
     },
     "suggest": {
         "laravel/framework": "To test the Laravel bindings",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,8 +8,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="true">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Preq Test Suite">
             <directory suffix="Test.php">./tests</directory>

--- a/src/AbstractCommand.php
+++ b/src/AbstractCommand.php
@@ -11,7 +11,7 @@ use Per3evere\Preq\Contract\Command as CommandContract;
 use Illuminate\Support\Arr;
 use Throwable;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Promise\promise_for;
+use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Exception\ClientException;
 
 abstract class AbstractCommand implements CommandContract
@@ -298,7 +298,7 @@ abstract class AbstractCommand implements CommandContract
 
                     $this->executionException = $reason;
                     $this->recordExecutionEvent(self::EVENT_FAILURE);
-                    return promise_for($this->getFallbackOrThrowException($reason));
+                    return Create::promiseFor($this->getFallbackOrThrowException($reason));
                 }
             );
 

--- a/src/IlluminateStateStorage.php
+++ b/src/IlluminateStateStorage.php
@@ -7,7 +7,7 @@ use Per3evere\Preq\Contract\StateStorage as StateStorageContract;
 
 class IlluminateStateStorage implements StateStorageContract
 {
-    const BUCKET_EXPIRE_MINUTES = 2;
+    const BUCKET_EXPIRE_SECONDS = 120;
 
     const CACHE_PREFIX = 'preq';
 
@@ -34,7 +34,9 @@ class IlluminateStateStorage implements StateStorageContract
 
     protected function prefix($name)
     {
-        $this->cache->setPrefix('');
+        if (method_exists($this->cache, 'setPrefix')) {
+            $this->cache->setPrefix('');
+        }
         return self::CACHE_PREFIX . '_' . $name;
     }
 
@@ -58,7 +60,7 @@ class IlluminateStateStorage implements StateStorageContract
     {
         $bucketName = $this->prefix($commandKey . '_' . $type . '_' . $index);
 
-        if (! $this->cache->add($bucketName, 1, self::BUCKET_EXPIRE_MINUTES)) {
+        if (! $this->cache->add($bucketName, 1, self::BUCKET_EXPIRE_SECONDS)) {
             $this->cache->increment($bucketName);
         }
     }
@@ -73,7 +75,7 @@ class IlluminateStateStorage implements StateStorageContract
         $bucketName = $this->prefix($commandKey . '_' . $type . '_' . $index);
 
         if ($this->cache->has($bucketName)) {
-            $this->cache->put($bucketName, 0, self::BUCKET_EXPIRE_MINUTES);
+            $this->cache->put($bucketName, 0, self::BUCKET_EXPIRE_SECONDS);
         }
     }
 
@@ -90,7 +92,7 @@ class IlluminateStateStorage implements StateStorageContract
         $this->cache->put($openedKey, true);
 
         $sleepingWindowInSeconds = ceil($sleepingWindowInMilliseconds / 1000);
-        $this->cache->add($singleTestFlagKey, true, $sleepingWindowInSeconds / 60);
+        $this->cache->add($singleTestFlagKey, true, $sleepingWindowInSeconds);
     }
 
     /**
@@ -104,7 +106,7 @@ class IlluminateStateStorage implements StateStorageContract
 
         $sleepingWindowInSeconds = ceil($sleepingWindowInMilliseconds / 1000);
 
-        return (boolean) $this->cache->add($singleTestFlagKey, true, $sleepingWindowInSeconds / 60);
+        return (boolean) $this->cache->add($singleTestFlagKey, true, $sleepingWindowInSeconds);
     }
 
     /**


### PR DESCRIPTION
* compatible with new versions of laravel

* fix

* fix bug

* update travis.yml

* guzzlehttp/promises的依赖版本从1.4.0开始

* 添加 tests 文件夹以修复phpunit错误

* 添加 php7.2 版本检测

* 增加兼容写法